### PR TITLE
Don't fail on missing apps for a given box

### DIFF
--- a/boites/models.py
+++ b/boites/models.py
@@ -32,8 +32,11 @@ class Boite(models.Model):
         apps_dict = {}
         for app in apps.get_models():
             if str(app._meta.app_label).startswith('app'):
-                app_dict = app.objects.get(boite = self).get_app_dictionary()
-                apps_dict = dict(apps_dict, **app_dict)
+                try:
+                    app_dict = app.objects.get(boite = self).get_app_dictionary()
+                    apps_dict = dict(apps_dict, **app_dict)
+                except app.DoesNotExist:
+                    pass
 
         return apps_dict
 


### PR DESCRIPTION
When displaying the data for a given box using a url such as
http://127.0.0.1:8000/boites/1/json/, the `app.objects.get` would fail if an
app was missing for this given box.

This is now fixed, if an app isn't added/configured for a box, it'll just get
ignored.