### PR TITLE
Scope app dictionnaries, add tests

### DIFF
--- a/app_parcel/tests.py
+++ b/app_parcel/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/app_tasks/tests.py
+++ b/app_tasks/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/app_time/tests.py
+++ b/app_time/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/app_weather/tests.py
+++ b/app_weather/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/boites/models.py
+++ b/boites/models.py
@@ -31,12 +31,12 @@ class Boite(models.Model):
     def get_apps_dictionary(self):
         apps_dict = {}
         for app in apps.get_models():
-            if str(app._meta.app_label).startswith('app'):
-                try:
-                    app_dict = app.objects.get(boite = self).get_app_dictionary()
-                    apps_dict = dict(apps_dict, **app_dict)
-                except app.DoesNotExist:
-                    pass
+            app_name = str(app._meta.app_label)
+            if app_name.startswith('app'):
+                applications = app.objects.filter(boite = self)
+                dicts = [a.get_app_dictionary() for a in applications]
+                if dicts:
+                    apps_dict[app_name] = dicts
 
         return apps_dict
 
@@ -56,7 +56,8 @@ class App(models.Model):
     last_activity = models.DateTimeField(_(u"Dernière activité"), auto_now = True)
 
     def get_app_dictionary(self):
-        pass
+        # Child classes need to implement this.
+        raise NotImplementedError
 
     class Meta:
         abstract = True

--- a/boites/tests.py
+++ b/boites/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=laboite.settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,10 @@ requests==2.9.2
 pycurl>=7.43.0
 
 git+git://git.symlink.me/pub/weboob/stable.git
+
+
+pytest==3.0.3
+pytest-cache==1.0
+pytest-django==3.0.0
+pytest-sugar==0.7.1
+pytest-watch==4.1.0

--- a/tests/boites/test_models.py
+++ b/tests/boites/test_models.py
@@ -1,0 +1,73 @@
+import pytest
+
+from boites.models import Boite
+from app_parcel.models import AppParcel
+
+
+@pytest.fixture
+def boite(admin_user):
+    boite, _ = Boite.objects.get_or_create(
+        name="Test boite",
+        user=admin_user,
+        api_key = "123")
+    yield boite
+
+
+@pytest.fixture
+def parcel(boite):
+    parcel = AppParcel.objects.create(
+        boite=boite,
+        parcel="parcel to track",
+        parcel_carrier="chronopost")
+    yield parcel
+
+
+def test_get_app_dictionnary(parcel):
+    assert parcel.get_app_dictionary() == {
+        "arrival": None,
+        "info": None,
+        "parcel": "parcel to track",
+        "status": None,
+        "parcel_carrier": "chronopost",
+    }
+
+
+def test_get_apps_dictionnary_single_app(parcel):
+    assert parcel.boite.get_apps_dictionary() == {
+        "app_parcel": [
+            {
+                "arrival": None,
+                "info": None,
+                "parcel": "parcel to track",
+                "status": None,
+                "parcel_carrier": "chronopost",
+            }
+        ]
+    }
+
+
+def test_get_apps_dictionnary_duplicated_apps(parcel):
+    parcel2 = parcel
+    parcel2.id = None
+    parcel2.save()  # Hack: save parcel2 as a new instance.
+    parcel2.parcel = "another parcel to track"
+    parcel2.parcel_carrier = "gls"
+    parcel2.save()
+    assert parcel.boite.get_apps_dictionary() == {
+        "app_parcel": [
+            {
+                "arrival": None,
+                "info": None,
+                "parcel": "parcel to track",
+                "status": None,
+                "parcel_carrier": "chronopost",
+            },
+            {
+                "arrival": None,
+                "info": None,
+                "parcel": "another parcel to track",
+                "status": None,
+                "parcel_carrier": "gls",
+            },
+        ]
+    }


### PR DESCRIPTION
To run the tests: `pytest`

For a "tdd like" workflow, use `ptw` instead which will re-run the tests on
each file change.