### PR TITLE
Use ugettext_lazy when doing translations at the 'module level'

### DIFF
--- a/app_alarm/models.py
+++ b/app_alarm/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from django.utils import timezone
 from datetime import timedelta

--- a/app_parcel/models.py
+++ b/app_parcel/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from django.utils import timezone
 from datetime import timedelta

--- a/app_tasks/models.py
+++ b/app_tasks/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from django.utils import timezone
 from datetime import timedelta

--- a/app_time/models.py
+++ b/app_time/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.db import models
 

--- a/app_traffic/models.py
+++ b/app_traffic/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import pycurl
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from StringIO import StringIO
 

--- a/app_weather/models.py
+++ b/app_weather/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.db import models
 

--- a/boites/models.py
+++ b/boites/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils import timezone
 from django.contrib.auth.models import User


### PR DESCRIPTION
If it's not using `ugettext_lazy`, then it'll just use the language of the first user after a server start, and use that to do all the translations at the module level (all the calls that aren't in a function call)